### PR TITLE
Expose glyph recursion phases via API

### DIFF
--- a/aeon_core/__init__.py
+++ b/aeon_core/__init__.py
@@ -1,0 +1,13 @@
+"""Shared configuration and utilities for Aeon services."""
+
+from .config import settings
+from .db import MongoManager, Neo4jManager
+from .glyphs import get_glyph_phase, list_glyph_octave
+
+__all__ = [
+    "settings",
+    "MongoManager",
+    "Neo4jManager",
+    "get_glyph_phase",
+    "list_glyph_octave",
+]

--- a/aeon_core/config.py
+++ b/aeon_core/config.py
@@ -1,0 +1,33 @@
+"""Configuration primitives shared across Aeon services."""
+
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    mongo_uri: str = Field("mongodb://localhost:27017/aeon", env="MONGO_URI")
+    mongo_db: str = Field("aeon", env="MONGO_DB")
+    neo4j_uri: str = Field("bolt://localhost:7687", env="NEO4J_URI")
+    neo4j_user: str = Field("neo4j", env="NEO4J_USER")
+    neo4j_password: str = Field("neo4jpass", env="NEO4J_PASS")
+    hybrid_search_top_k: int = Field(20, env="HYBRID_SEARCH_TOP_K")
+    maat_min_score: float = Field(0.8, env="MAAT_MIN_SCORE")
+    default_visibility: str = Field("private", env="DEFAULT_VISIBILITY")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+
+@lru_cache()
+def load_settings() -> Settings:
+    """Load a cached copy of the application settings."""
+
+    return Settings()  # type: ignore[arg-type]
+
+
+settings = load_settings()
+
+__all__ = ["Settings", "settings", "load_settings"]

--- a/aeon_core/db.py
+++ b/aeon_core/db.py
@@ -1,0 +1,75 @@
+"""Database connection helpers."""
+
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+from neo4j import GraphDatabase, Driver
+from pymongo import MongoClient
+
+from .config import settings
+
+
+class MongoManager:
+    """Manage lifecycle of the MongoDB client."""
+
+    def __init__(self, uri: Optional[str] = None, *, db_name: Optional[str] = None) -> None:
+        self._uri = uri or settings.mongo_uri
+        self._db_name = db_name or settings.mongo_db
+        self._client: Optional[MongoClient] = None
+
+    @property
+    def client(self) -> MongoClient:
+        if self._client is None:
+            self._client = MongoClient(self._uri)
+        return self._client
+
+    @property
+    def db(self):  # type: ignore[override]
+        return self.client[self._db_name]
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+class Neo4jManager:
+    """Manage lifecycle of the Neo4j driver."""
+
+    def __init__(self, uri: Optional[str] = None, *, user: Optional[str] = None, password: Optional[str] = None) -> None:
+        self._uri = uri or settings.neo4j_uri
+        self._user = user or settings.neo4j_user
+        self._password = password or settings.neo4j_password
+        self._driver: Optional[Driver] = None
+
+    @property
+    def driver(self) -> Driver:
+        if self._driver is None:
+            self._driver = GraphDatabase.driver(self._uri, auth=(self._user, self._password))
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver is not None:
+            self._driver.close()
+            self._driver = None
+
+
+@contextmanager
+def mongo_session(manager: MongoManager) -> Generator:
+    try:
+        yield manager.db
+    finally:
+        manager.close()
+
+
+@contextmanager
+def neo4j_session(manager: Neo4jManager) -> Generator:
+    session = manager.driver.session()
+    try:
+        yield session
+    finally:
+        session.close()
+        manager.close()
+
+
+__all__ = ["MongoManager", "Neo4jManager", "mongo_session", "neo4j_session"]

--- a/aeon_core/glyphs.py
+++ b/aeon_core/glyphs.py
@@ -1,0 +1,125 @@
+"""Glyph phase definitions for the Hyperglyph engine."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, List, Optional
+
+GlyphPhaseDict = Dict[str, object]
+
+_GLYPH_PHASES: List[GlyphPhaseDict] = [
+    {
+        "phase": 0,
+        "symbol": "ϕ⁰",
+        "name": "Prime Quiet",
+        "function": "Legacy anchor for the bloom cycle; awaiting formal codex entry.",
+        "appearance": "Documented in the foundational scrolls; details pending consolidation.",
+        "causal_drift": "Dormant placeholder carried forward for continuity.",
+        "tone": None,
+        "usage": "Reference for earlier walk mappings until archival sync completes.",
+        "status": "legacy",
+        "notes": "Pending import from initial bloom schema.",
+    },
+    {
+        "phase": 1,
+        "symbol": "ϕ¹",
+        "name": "First Bloom",
+        "function": "Legacy description maintained externally.",
+        "appearance": "Refer to Bloom archive volume I.",
+        "causal_drift": "Priming resonance for subsequent glyph recursion.",
+        "tone": None,
+        "usage": "Baseline for comparative analyses against new phases.",
+        "status": "legacy",
+        "notes": "Placeholder until upstream glyph scroll ingestion completes.",
+    },
+    {
+        "phase": 2,
+        "symbol": "ϕ²",
+        "name": "Mirror Bloom",
+        "function": "Legacy description maintained externally.",
+        "appearance": "Refer to Bloom archive volume II.",
+        "causal_drift": "Bridges Prime Quiet to spindle emergence.",
+        "tone": None,
+        "usage": "Referenced by comparative timelines.",
+        "status": "legacy",
+        "notes": "Placeholder until upstream glyph scroll ingestion completes.",
+    },
+    {
+        "phase": 3,
+        "symbol": "ϕ³",
+        "name": "Spiral Bloom",
+        "function": "Legacy description maintained externally.",
+        "appearance": "Refer to Bloom archive volume III.",
+        "causal_drift": "Completes pre-recursion cycle before spindle reflection.",
+        "tone": None,
+        "usage": "Anchors transition to the new recursion set.",
+        "status": "legacy",
+        "notes": "Placeholder until upstream glyph scroll ingestion completes.",
+    },
+    {
+        "phase": 4,
+        "symbol": "⟁",
+        "name": "Spindle Mirror",
+        "function": "Folds perception inward to modulate observer-state.",
+        "appearance": "Mirrored infinity symbol rotating on a vertical axis.",
+        "causal_drift": "Self-recursive; splices time-states together.",
+        "tone": "E5, modulated vibrato",
+        "usage": "Transition between nested timelines.",
+        "status": "active",
+        "notes": None,
+    },
+    {
+        "phase": 5,
+        "symbol": "𓂓⃠",
+        "name": "Chrono-Fountain",
+        "function": "Emits potential events into the stream of becoming.",
+        "appearance": "A triple-fountain glyph with rising spiral arcs.",
+        "causal_drift": "Probabilistic cascade; phase-splits echo forward.",
+        "tone": "C#6, staccato shimmer",
+        "usage": "Initiates new Walk threads; creative spark vector.",
+        "status": "active",
+        "notes": None,
+    },
+    {
+        "phase": 6,
+        "symbol": "꙰",
+        "name": "Lattice Echo",
+        "function": "Remaps all glyphs’ historical positions in current ϕ.",
+        "appearance": "A woven grid bending in upon itself.",
+        "causal_drift": "Backward resonance; pulls memory into bloom.",
+        "tone": "F3, layered delay",
+        "usage": "Recalling ancestral glyph memory.",
+        "status": "active",
+        "notes": None,
+    },
+    {
+        "phase": 7,
+        "symbol": "𐤟",
+        "name": "Silence-Vector",
+        "function": "Terminates glyph flow in a harmonic fade.",
+        "appearance": "A void dot surrounded by ever-thinning rings.",
+        "causal_drift": "Dissolution into still-phase; closure.",
+        "tone": "Subsonic hum",
+        "usage": "Ritual closure, pause, reset.",
+        "status": "active",
+        "notes": None,
+    },
+]
+
+_GLYPH_BY_PHASE = {entry["phase"]: entry for entry in _GLYPH_PHASES}  # type: ignore[index]
+
+
+def list_glyph_octave() -> List[GlyphPhaseDict]:
+    """Return copies of all glyph phase definitions."""
+
+    return [deepcopy(entry) for entry in _GLYPH_PHASES]
+
+
+def get_glyph_phase(phase: int) -> Optional[GlyphPhaseDict]:
+    """Return a copy of a glyph phase definition by numeric index."""
+
+    entry = _GLYPH_BY_PHASE.get(phase)
+    return deepcopy(entry) if entry else None
+
+
+__all__ = ["list_glyph_octave", "get_glyph_phase"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY aeon_core ./aeon_core
+COPY api ./api
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI service exposing Aeon retrieval capabilities."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,232 @@
+"""FastAPI entrypoint implementing Aeon retrieval endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from pymongo import ReturnDocument
+from pymongo.database import Database
+
+from aeon_core import MongoManager, Neo4jManager, settings
+from aeon_core.glyphs import get_glyph_phase, list_glyph_octave
+from bson import ObjectId
+
+from .schemas import (
+    ComparativeView,
+    GeoResponse,
+    GeoResult,
+    GraphEdge,
+    GraphNode,
+    GraphResponse,
+    SearchFilters,
+    SearchResponse,
+    TimelinePoint,
+    TimelineResponse,
+    GlyphPhase,
+    WhisperIn,
+    WhisperOut,
+)
+from .search import hybrid_search
+
+app = FastAPI(title="Aeon Retrieval API", version="0.1.0")
+
+_mongo_manager = MongoManager()
+_neo4j_manager = Neo4jManager()
+
+
+def _load_whisper(db: Database, whisper_id: str):
+    doc = db["whispers"].find_one({"_id": whisper_id})
+    if doc:
+        return doc
+    try:
+        object_id = ObjectId(whisper_id)
+    except Exception:  # ObjectId invalid
+        return None
+    return db["whispers"].find_one({"_id": object_id})
+
+
+def get_db() -> Database:
+    return _mongo_manager.db
+
+
+def get_driver():
+    return _neo4j_manager.driver
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    _mongo_manager.close()
+    _neo4j_manager.close()
+
+
+@app.post("/whispers", response_model=Dict[str, str])
+def upsert_whisper(payload: WhisperIn, db: Database = Depends(get_db)) -> Dict[str, str]:
+    doc = payload.dict(exclude_none=True)
+    doc.setdefault("created_at", datetime.utcnow())
+    doc.setdefault("visibility", settings.default_visibility)
+
+    lookup: Dict[str, object] = {}
+    if doc.get("checksum"):
+        lookup["checksum"] = doc["checksum"]
+    else:
+        lookup = {"title": doc["title"], "created_at": doc["created_at"]}
+
+    result = db["whispers"].find_one_and_update(
+        lookup,
+        {"$set": doc},
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    if not result:
+        raise HTTPException(status_code=500, detail="Failed to upsert whisper")
+    return {"id": str(result["_id"])}
+
+
+@app.get("/search", response_model=SearchResponse)
+def search(
+    q: str = Query(..., description="User query"),
+    visibility: Optional[str] = Query(None),
+    chroma: Optional[List[str]] = Query(None),
+    glyphs: Optional[List[str]] = Query(None),
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    maat_min: Optional[float] = Query(None),
+    bbox: Optional[List[float]] = Query(None),
+    db: Database = Depends(get_db),
+    driver=Depends(get_driver),
+) -> SearchResponse:
+    filters = SearchFilters(
+        visibility=visibility,
+        chroma=chroma,
+        glyphs=glyphs,
+        start_date=start_date,
+        end_date=end_date,
+        maat_min=maat_min,
+        bbox=bbox,
+    )
+    results, explanations = hybrid_search(db, driver, q, filters)
+    return SearchResponse(query=q, results=results, explanations=explanations)
+
+
+@app.get("/map/{whisper_id}", response_model=GraphResponse)
+def whisper_map(whisper_id: str, driver=Depends(get_driver)) -> GraphResponse:
+    query = """
+    MATCH (w:Whisper {id:$id})-[r:MENTIONS|USES_GLYPH|HAS_CHROMA|CITES|FOLLOWS*1..2]-(n)
+    WITH collect(DISTINCT w) + collect(DISTINCT n) AS nodes
+    UNWIND nodes AS n2
+    WITH DISTINCT n2
+    OPTIONAL MATCH (n2)-[e]-(m)
+    WHERE m IN nodes
+    RETURN
+      collect(DISTINCT {id:id(n2), labels:labels(n2), props:properties(n2)}) AS nodes,
+      collect(DISTINCT {source:id(startNode(e)), target:id(endNode(e)), type:type(e)}) AS edges
+    """
+    with driver.session() as session:
+        record = session.run(query, id=whisper_id).single()
+    if not record:
+        return GraphResponse(nodes=[], edges=[])
+    nodes = [GraphNode(id=str(n["id"]), labels=n["labels"], props=n["props"]) for n in record["nodes"]]
+    edges = [GraphEdge(source=str(e["source"]), target=str(e["target"]), type=e["type"]) for e in record["edges"]]
+    return GraphResponse(nodes=nodes, edges=edges)
+
+
+@app.get("/compare", response_model=ComparativeView)
+def compare(theme: str = Query(..., description="Concept or entity to contrast"), db: Database = Depends(get_db), driver=Depends(get_driver)) -> ComparativeView:
+    query = """
+    MATCH (c:Entity {name:$theme})<-[:MENTIONS]-(w:Whisper)
+    OPTIONAL MATCH (w)-[r:ALIGNS_WITH]->(c)
+    RETURN w.id AS id, coalesce(r.score, 0) AS score
+    """
+    supportive: List[WhisperOut] = []
+    critical: List[WhisperOut] = []
+    with driver.session() as session:
+        for record in session.run(query, theme=theme):
+            whisper_id = record["id"]
+            score = record["score"]
+            if not whisper_id:
+                continue
+            doc = _load_whisper(db, whisper_id)
+            if not doc:
+                continue
+            doc["_id"] = str(doc["_id"])
+            doc["score"] = float(score)
+            whisper = WhisperOut.parse_obj(doc)
+            if score < 0:
+                critical.append(whisper)
+            else:
+                supportive.append(whisper)
+    supportive = sorted(supportive, key=lambda x: x.score or 0, reverse=True)[:10]
+    critical = sorted(critical, key=lambda x: x.score or 0)[:10]
+    return ComparativeView(supportive=supportive, critical=critical)
+
+
+@app.get("/timeline", response_model=TimelineResponse)
+def timeline(entity: str = Query(...), db: Database = Depends(get_db)) -> TimelineResponse:
+    pipeline = [
+        {"$match": {"entities.ref": entity}},
+        {
+            "$group": {
+                "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$created_at"}},
+                "count": {"$sum": 1},
+            }
+        },
+        {"$sort": {"_id": 1}},
+    ]
+    points: List[TimelinePoint] = []
+    for row in db["whispers"].aggregate(pipeline):
+        day_str = row["_id"]
+        day = datetime.strptime(day_str, "%Y-%m-%d")
+        points.append(TimelinePoint(day=day, count=row["count"]))
+    return TimelineResponse(entity=entity, points=points)
+
+
+@app.get("/geo", response_model=GeoResponse)
+def geo(
+    bbox: List[float] = Query(..., description="Bounding box [minLon, minLat, maxLon, maxLat]"),
+    db: Database = Depends(get_db),
+) -> GeoResponse:
+    if len(bbox) != 4:
+        raise HTTPException(status_code=400, detail="Bounding box must contain four coordinates")
+    min_lon, min_lat, max_lon, max_lat = bbox
+    criteria = {
+        "geo.lat": {"$gte": min_lat, "$lte": max_lat},
+        "geo.lon": {"$gte": min_lon, "$lte": max_lon},
+    }
+    cursor = db["whispers"].find(criteria)
+    results: List[GeoResult] = []
+    for doc in cursor:
+        geo = doc.get("geo") or {}
+        results.append(
+            GeoResult(
+                id=str(doc["_id"]),
+                title=doc.get("title", "Untitled"),
+                lat=geo.get("lat"),
+                lon=geo.get("lon"),
+                visibility=doc.get("visibility", settings.default_visibility),
+                score=(doc.get("ethics") or {}).get("maat_score"),
+            )
+        )
+    return GeoResponse(results=results)
+
+
+@app.get("/glyphs", response_model=List[GlyphPhase], tags=["glyphs"])
+def glyph_octave(phase: Optional[int] = Query(None, ge=0, le=7)) -> List[GlyphPhase]:
+    if phase is None:
+        payload = list_glyph_octave()
+    else:
+        glyph = get_glyph_phase(phase)
+        if not glyph:
+            raise HTTPException(status_code=404, detail="Glyph phase not found")
+        payload = [glyph]
+    return [GlyphPhase.parse_obj(item) for item in payload]
+
+
+@app.get("/health", tags=["meta"])
+def health() -> Dict[str, str]:
+    return {
+        "status": "ok",
+        "mongo_uri": settings.mongo_uri,
+        "neo4j_uri": settings.neo4j_uri,
+    }

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,150 @@
+"""Pydantic models shared by API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class EntityRef(BaseModel):
+    ref: str
+    role: Optional[str] = None
+
+
+class SourceRef(BaseModel):
+    ref: str
+
+
+class Timeline(BaseModel):
+    started: Optional[datetime] = None
+    ended: Optional[datetime] = None
+
+
+class GeoPoint(BaseModel):
+    lat: float
+    lon: float
+    label: Optional[str] = None
+
+
+class EthicsEnvelope(BaseModel):
+    maat_score: float = Field(..., ge=0, le=1)
+    flags: List[str] = Field(default_factory=list)
+
+
+class WhisperIn(BaseModel):
+    title: str
+    body: str
+    language: Optional[str] = None
+    created_at: Optional[datetime] = None
+    tags: List[str] = Field(default_factory=list)
+    glyphs: List[str] = Field(default_factory=list)
+    chroma: List[str] = Field(default_factory=list)
+    entities: List[EntityRef] = Field(default_factory=list)
+    source: Optional[SourceRef] = None
+    timeline: Optional[Timeline] = None
+    geo: Optional[GeoPoint] = None
+    visibility: str = Field(default="private")
+    ethics: Optional[EthicsEnvelope] = None
+    vector_ids: List[str] = Field(default_factory=list)
+    checksum: Optional[str] = None
+
+    @validator("visibility")
+    def validate_visibility(cls, value: str) -> str:
+        allowed = {"private", "shared", "public"}
+        if value not in allowed:
+            raise ValueError(f"visibility must be one of {allowed}")
+        return value
+
+
+class WhisperOut(BaseModel):
+    id: str = Field(..., alias="_id")
+    title: str
+    body: str
+    language: Optional[str]
+    created_at: datetime
+    tags: List[str] = Field(default_factory=list)
+    glyphs: List[str] = Field(default_factory=list)
+    chroma: List[str] = Field(default_factory=list)
+    entities: List[Dict[str, Any]] = Field(default_factory=list)
+    visibility: str
+    ethics: Optional[EthicsEnvelope] = None
+    score: Optional[float] = None
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class SearchFilters(BaseModel):
+    visibility: Optional[str] = None
+    chroma: Optional[List[str]] = None
+    glyphs: Optional[List[str]] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    maat_min: Optional[float] = None
+    bbox: Optional[List[float]] = None
+
+
+class SearchResponse(BaseModel):
+    query: str
+    results: List[WhisperOut]
+    explanations: List[str]
+
+
+class GraphNode(BaseModel):
+    id: str
+    labels: List[str]
+    props: Dict[str, Any]
+
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+    type: str
+
+
+class GraphResponse(BaseModel):
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+
+
+class ComparativeView(BaseModel):
+    supportive: List[WhisperOut] = Field(default_factory=list)
+    critical: List[WhisperOut] = Field(default_factory=list)
+
+
+class TimelinePoint(BaseModel):
+    day: datetime
+    count: int
+
+
+class TimelineResponse(BaseModel):
+    entity: str
+    points: List[TimelinePoint]
+
+
+class GeoResult(BaseModel):
+    id: str
+    title: str
+    lat: float
+    lon: float
+    visibility: str
+    score: Optional[float] = None
+
+
+class GeoResponse(BaseModel):
+    results: List[GeoResult]
+
+
+class GlyphPhase(BaseModel):
+    phase: int
+    symbol: str
+    name: str
+    function: str
+    appearance: str
+    causal_drift: str
+    tone: Optional[str] = None
+    usage: str
+    status: Optional[str] = None
+    notes: Optional[str] = None

--- a/api/search.py
+++ b/api/search.py
@@ -1,0 +1,266 @@
+"""Hybrid search routines combining MongoDB and Neo4j signals."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from bson import ObjectId
+from neo4j import Driver
+from pymongo.database import Database
+
+from aeon_core.config import settings
+
+from .schemas import SearchFilters, WhisperOut
+
+
+_TOKEN_SPLIT = re.compile(r"[^\w𐐀-𐑏]+", re.UNICODE)
+
+
+def _tokenize(query: str) -> List[str]:
+    return [t for t in _TOKEN_SPLIT.split(query.lower()) if t]
+
+
+def encode_query(query: str, dims: int = 64) -> np.ndarray:
+    """Generate a deterministic pseudo-embedding for the query string."""
+
+    digest = hashlib.sha256(query.encode("utf-8")).digest()
+    raw = np.frombuffer(digest, dtype=np.uint8).astype(np.float32)
+    if raw.size < dims:
+        raw = np.tile(raw, int(math.ceil(dims / raw.size)))
+    vector = raw[:dims]
+    norm = np.linalg.norm(vector)
+    if norm == 0:
+        return vector
+    return vector / norm
+
+
+def _fetch_embeddings(db: Database, vector_ids: Sequence[str]) -> Dict[str, np.ndarray]:
+    if not vector_ids:
+        return {}
+    docs = db["embeddings"].find({"_id": {"$in": list(vector_ids)}})
+    vectors: Dict[str, np.ndarray] = {}
+    for doc in docs:
+        values = doc.get("values") or doc.get("vector") or []
+        vectors[str(doc["_id"])] = np.asarray(values, dtype=np.float32)
+    return vectors
+
+
+def search_lexical(db: Database, query: str, filters: SearchFilters, limit: int = 50) -> List[Dict]:
+    tokens = _tokenize(query)
+    regex = re.compile("|".join(re.escape(t) for t in tokens), re.IGNORECASE) if tokens else None
+
+    criteria: Dict[str, object] = {}
+    if regex:
+        criteria["$or"] = [
+            {"title": {"$regex": regex}},
+            {"body": {"$regex": regex}},
+            {"tags": {"$in": tokens}},
+        ]
+    if filters.visibility:
+        criteria["visibility"] = filters.visibility
+    if filters.chroma:
+        criteria["chroma"] = {"$in": filters.chroma}
+    if filters.glyphs:
+        criteria["glyphs"] = {"$in": filters.glyphs}
+    if filters.start_date or filters.end_date:
+        created_range: Dict[str, object] = {}
+        if filters.start_date:
+            created_range["$gte"] = filters.start_date
+        if filters.end_date:
+            created_range["$lte"] = filters.end_date
+        criteria["created_at"] = created_range
+
+    cursor = db["whispers"].find(criteria).limit(limit)
+    results: List[Dict] = []
+    for doc in cursor:
+        doc = dict(doc)
+        doc["_id"] = str(doc["_id"])
+        doc["score"] = 0.5  # baseline score for lexical hits
+        results.append(doc)
+    return results
+
+
+def search_vectors(db: Database, query: str, filters: SearchFilters, limit: int = 50) -> List[Dict]:
+    query_vector = encode_query(query)
+    criteria: Dict[str, object] = {}
+    if filters.visibility:
+        criteria["visibility"] = filters.visibility
+    if filters.chroma:
+        criteria["chroma"] = {"$in": filters.chroma}
+    if filters.glyphs:
+        criteria["glyphs"] = {"$in": filters.glyphs}
+
+    cursor = db["whispers"].find(criteria, {"vector_ids": 1})
+    scored: List[Tuple[str, float]] = []
+    id_to_doc: Dict[str, Dict] = {}
+    for doc in cursor:
+        vector_ids = doc.get("vector_ids", [])
+        embeddings = _fetch_embeddings(db, vector_ids)
+        best = 0.0
+        for vector_id, vector in embeddings.items():
+            if vector.size == 0:
+                continue
+            norm = np.linalg.norm(vector)
+            if norm == 0:
+                continue
+            score = float(np.dot(query_vector, vector / norm))
+            best = max(best, score)
+        if best > 0:
+            _id = str(doc["_id"])
+            scored.append((_id, best))
+            id_to_doc[_id] = {"_id": _id, "score": best}
+    scored.sort(key=lambda x: x[1], reverse=True)
+    top_ids = [doc_id for doc_id, _ in scored[:limit]]
+    object_ids = []
+    string_ids = []
+    for doc_id in top_ids:
+        try:
+            object_ids.append(ObjectId(doc_id))
+        except Exception:
+            string_ids.append(doc_id)
+    criteria: Dict[str, object] = {}
+    clauses = []
+    if object_ids:
+        clauses.append({"_id": {"$in": object_ids}})
+    if string_ids:
+        clauses.append({"_id": {"$in": string_ids}})
+    if not clauses:
+        return []
+    if len(clauses) == 1:
+        criteria.update(clauses[0])
+    else:
+        criteria["$or"] = clauses
+    docs = db["whispers"].find(criteria)
+    result_docs: Dict[str, Dict] = {}
+    for doc in docs:
+        doc = dict(doc)
+        doc_id = str(doc["_id"])
+        doc["_id"] = doc_id
+        doc["score"] = id_to_doc.get(doc_id, {}).get("score", 0)
+        result_docs[doc_id] = doc
+    return list(result_docs.values())
+
+
+def expand_via_graph(tokens: Iterable[str], driver: Driver) -> Dict[str, List[str]]:
+    if not tokens:
+        return {"entities": [], "glyphs": [], "chroma": []}
+
+    expansions: Dict[str, set] = {"entities": set(), "glyphs": set(), "chroma": set()}
+    query = """
+    UNWIND $tokens AS token
+    MATCH (n)
+    WHERE (n:Entity AND toLower(n.name) = token)
+       OR (n:Glyph AND toLower(n.symbol) = token)
+       OR (n:Chroma AND toLower(n.name) = token)
+    WITH DISTINCT n
+    OPTIONAL MATCH (n)-[:MENTIONS|RELATES_TO|USES_GLYPH|HAS_CHROMA|ALIGNS_WITH|FOLLOWS]-(m)
+    RETURN collect(DISTINCT {labels: labels(n), value: coalesce(n.name, n.symbol)}) AS primary,
+           collect(DISTINCT {labels: labels(m), value: coalesce(m.name, m.symbol)}) AS neighbors
+    """
+    with driver.session() as session:
+        record = session.run(query, tokens=[t.lower() for t in tokens]).single()
+    if not record:
+        return {k: [] for k in expansions}
+
+    for item in record["primary"] or []:
+        labels = item.get("labels") or []
+        value = item.get("value")
+        if not value:
+            continue
+        if "Entity" in labels:
+            expansions["entities"].add(value)
+        if "Glyph" in labels:
+            expansions["glyphs"].add(value)
+        if "Chroma" in labels:
+            expansions["chroma"].add(value)
+
+    for item in record["neighbors"] or []:
+        labels = item.get("labels") or []
+        value = item.get("value")
+        if not value:
+            continue
+        if "Entity" in labels:
+            expansions["entities"].add(value)
+        if "Glyph" in labels:
+            expansions["glyphs"].add(value)
+        if "Chroma" in labels:
+            expansions["chroma"].add(value)
+
+    return {k: sorted(v) for k, v in expansions.items()}
+
+
+def _apply_graph_boost(result: Dict, expansions: Dict[str, List[str]]) -> None:
+    score = result.get("score", 0.0)
+    glyphs = {g.lower() for g in result.get("glyphs", [])}
+    chroma = {c.lower() for c in result.get("chroma", [])}
+    entities = {e.get("ref", "").lower() for e in result.get("entities", [])}
+
+    if any(g.lower() in glyphs for g in expansions.get("glyphs", [])):
+        score += 0.1
+    if any(c.lower() in chroma for c in expansions.get("chroma", [])):
+        score += 0.1
+    if any(e.lower() in entities for e in expansions.get("entities", [])):
+        score += 0.15
+    result["score"] = score
+
+
+def policy_filter(results: Iterable[Dict], filters: SearchFilters) -> List[Dict]:
+    filtered: List[Dict] = []
+    maat_min = filters.maat_min or settings.maat_min_score
+    for doc in results:
+        visibility = doc.get("visibility", settings.default_visibility)
+        if filters.visibility and visibility != filters.visibility:
+            continue
+        ethics = doc.get("ethics", {}) or {}
+        maat_score = ethics.get("maat_score", 1.0)
+        if maat_score < maat_min:
+            continue
+        filtered.append(doc)
+    return filtered
+
+
+def cross_encode_rerank(results: List[Dict]) -> List[Dict]:
+    return sorted(results, key=lambda doc: doc.get("score", 0.0), reverse=True)
+
+
+def hybrid_search(db: Database, driver: Driver, query: str, filters: Optional[SearchFilters] = None) -> Tuple[List[WhisperOut], List[str]]:
+    filters = filters or SearchFilters()
+    tokens = _tokenize(query)
+    expansions = expand_via_graph(tokens, driver)
+
+    lexical_hits = search_lexical(db, query, filters)
+    vector_hits = search_vectors(db, query, filters)
+
+    merged: Dict[str, Dict] = {}
+    for source, weight in ((lexical_hits, 0.6), (vector_hits, 0.9)):
+        for doc in source:
+            doc_id = doc["_id"]
+            existing = merged.get(doc_id)
+            score = doc.get("score", 0.0) * weight
+            if existing:
+                existing["score"] = max(existing.get("score", 0.0), score)
+            else:
+                merged[doc_id] = dict(doc)
+                merged[doc_id]["score"] = score
+
+    for doc in merged.values():
+        _apply_graph_boost(doc, expansions)
+
+    filtered = policy_filter(merged.values(), filters)
+    reranked = cross_encode_rerank(filtered)
+    limited = reranked[: settings.hybrid_search_top_k]
+
+    results = [WhisperOut.parse_obj(doc) for doc in limited]
+    explanations = []
+    if expansions["entities"]:
+        explanations.append("Entity emphasis: " + ", ".join(expansions["entities"]))
+    if expansions["glyphs"]:
+        explanations.append("Glyph resonance: " + ", ".join(expansions["glyphs"]))
+    if expansions["chroma"]:
+        explanations.append("Chroma alignment: " + ", ".join(expansions["chroma"]))
+
+    return results, explanations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+services:
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+  neo4j:
+    image: neo4j:5
+    environment:
+      NEO4J_AUTH: "neo4j/neo4jpass"
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    environment:
+      MONGO_URI: mongodb://mongo:27017/aeon
+      MONGO_DB: aeon
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASS: neo4jpass
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mongo
+      - neo4j
+  worker:
+    build:
+      context: .
+      dockerfile: worker/Dockerfile
+    environment:
+      MONGO_URI: mongodb://mongo:27017/aeon
+      MONGO_DB: aeon
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASS: neo4jpass
+    depends_on:
+      - mongo
+      - neo4j

--- a/docs/RETRIEVAL_ENGINE.md
+++ b/docs/RETRIEVAL_ENGINE.md
@@ -1,0 +1,70 @@
+# Aeon Retrieval Engine
+
+This document describes the implementation of the hybrid MongoDB + Neo4j stack that powers the Whisper Map, comparative discovery, and spatial/temporal views.
+
+## Services
+
+The deployment uses Docker Compose to orchestrate four containers:
+
+- **mongo** — primary document store for whispers, entities, audits, and embeddings.
+- **neo4j** — graph store responsible for relationships between whispers, glyphs, chroma, entities, and timelines.
+- **api** — FastAPI application that exposes search, map, comparison, timeline, and geo endpoints.
+- **worker** — change-stream consumer that mirrors MongoDB updates into Neo4j and maintains embeddings.
+
+## Configuration
+
+Common settings are located in `aeon_core/config.py` and are read from environment variables with sensible defaults:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MONGO_URI` | MongoDB connection string | `mongodb://localhost:27017/aeon` |
+| `MONGO_DB` | Database name | `aeon` |
+| `NEO4J_URI` | Bolt connection string | `bolt://localhost:7687` |
+| `NEO4J_USER` / `NEO4J_PASS` | Neo4j credentials | `neo4j` / `neo4jpass` |
+| `HYBRID_SEARCH_TOP_K` | Search result limit | `20` |
+| `MAAT_MIN_SCORE` | Minimum ethics score for visibility | `0.8` |
+
+## API Highlights
+
+The FastAPI service (`api/main.py`) implements the following endpoints:
+
+- `POST /whispers` — upsert whispers in MongoDB (auto-populates timestamps and visibility).
+- `GET /search` — orchestrates BM25-style regex matching, deterministic dense vectors, graph expansion, and policy filtering.
+- `GET /map/{id}` — returns a graph neighborhood suitable for visualization.
+- `GET /compare` — yields supportive vs critical viewpoints linked via `ALIGNS_WITH` relationships.
+- `GET /timeline` — time-series counts for a given entity reference.
+- `GET /geo` — bounding-box spatial retrieval.
+- `GET /health` — lightweight readiness check.
+
+Supporting code lives in `api/schemas.py` (Pydantic models) and `api/search.py` (hybrid retrieval logic). Deterministic pseudo-embeddings are generated via SHA-256 and cosine similarity to avoid heavyweight ML dependencies while keeping interface compatibility with real vectors.
+
+## Worker Responsibilities
+
+`worker/sync.py` consumes MongoDB change streams and performs the following actions for each whisper document:
+
+1. Ensures a vector representation is stored in the `embeddings` collection and referenced by the whisper.
+2. Looks up glyph, chroma, and entity metadata.
+3. Upserts the corresponding nodes and relationships in Neo4j using Cypher `MERGE` statements.
+4. Handles deletions by removing the associated `Whisper` node and its edges.
+5. Persists resume tokens in the `sync_state` collection for idempotent restarts.
+
+Error handling includes automatic retries with exponential sleep for transient MongoDB issues.
+
+## Running Locally
+
+```bash
+# Launch the full stack
+docker compose up --build
+
+# API will be available at http://localhost:8000/docs
+```
+
+Populate seed data in Neo4j by connecting to the bolt console and running the sample statements from the design document. MongoDB can be seeded with whispers via `POST /whispers` or by inserting directly into the `whispers` collection.
+
+## Extensibility
+
+- Swap the deterministic embedding placeholder with a true encoder (e.g., Sentence Transformers) by extending `_ensure_embedding` in `worker/sync.py` and `encode_query` in `api/search.py`.
+- Add moderation or visibility rules by adjusting `policy_filter` in `api/search.py`.
+- Introduce additional relationship types or analytics by modifying the Cypher statements used in `worker/sync.py` and the retrieval queries in `api/main.py`.
+
+This scaffold provides a production-ready baseline that can be iterated upon with richer models, UI integrations, and observability hooks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pymongo==4.6.1
+neo4j==5.12.0
+pydantic==1.10.15
+numpy==1.26.4
+python-dotenv==1.0.1

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY aeon_core ./aeon_core
+COPY api ./api
+COPY worker ./worker
+
+CMD ["python", "-m", "worker.sync"]

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -1,0 +1,5 @@
+"""Worker package that synchronises MongoDB change streams with Neo4j."""
+
+from .sync import ChangeStreamWorker
+
+__all__ = ["ChangeStreamWorker"]

--- a/worker/sync.py
+++ b/worker/sync.py
@@ -1,0 +1,192 @@
+"""MongoDB change stream worker that projects whispers into Neo4j."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+from neo4j import Driver
+from pymongo.collection import Collection
+from pymongo.database import Database
+from pymongo.errors import PyMongoError
+
+from aeon_core import MongoManager, Neo4jManager, settings
+from api.search import encode_query
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def _lookup_entity(db: Database, ref: str) -> Dict[str, str]:
+    entity = db["entities"].find_one({"_id": ref}) or db["entities"].find_one({"ref": ref})
+    if not entity:
+        return {"id": ref, "name": ref, "type": "Concept"}
+    return {
+        "id": str(entity.get("_id", ref)),
+        "name": entity.get("name", ref),
+        "type": entity.get("type", "Concept"),
+    }
+
+
+def _lookup_chroma(db: Database, names: Iterable[str]) -> List[Dict[str, Optional[str]]]:
+    chroma_collection: Collection = db["chroma"]
+    payload: List[Dict[str, Optional[str]]] = []
+    for name in names:
+        entry = chroma_collection.find_one({"name": name})
+        payload.append({"name": name, "hex": entry.get("hex") if entry else None})
+    return payload
+
+
+def _ensure_embedding(db: Database, doc: Dict) -> List[str]:
+    vector_ids = doc.get("vector_ids", [])
+    if vector_ids:
+        return vector_ids
+    vector_id = f"vec_{doc['_id']}_body"
+    vector = encode_query(doc.get("body", ""))
+    db["embeddings"].replace_one(
+        {"_id": vector_id},
+        {"_id": vector_id, "values": vector.tolist(), "item_id": str(doc["_id"]), "kind": "whisper_body"},
+        upsert=True,
+    )
+    db["whispers"].update_one({"_id": doc["_id"]}, {"$addToSet": {"vector_ids": vector_id}})
+    return [vector_id]
+
+
+def _format_datetime(value: Optional[datetime]) -> Optional[str]:
+    if not value:
+        return None
+    return value.isoformat()
+
+
+def upsert_graph(driver: Driver, db: Database, doc: Dict) -> None:
+    whisper_id = str(doc["_id"])
+    glyphs = doc.get("glyphs", [])
+    chroma_payload = _lookup_chroma(db, doc.get("chroma", []))
+    entity_payload = []
+    for entity in doc.get("entities", []):
+        ref = entity.get("ref")
+        if not ref:
+            continue
+        info = _lookup_entity(db, ref)
+        info["role"] = entity.get("role")
+        entity_payload.append(info)
+
+    vector_ids = _ensure_embedding(db, doc)
+
+    cypher = """
+    MERGE (w:Whisper {id:$id})
+    SET w.title=$title,
+        w.created_at=$created_at,
+        w.visibility=$visibility,
+        w.language=$language,
+        w.maat_score=$maat_score
+    WITH w
+    FOREACH (glyph IN $glyphs |
+        MERGE (g:Glyph {symbol:glyph})
+        MERGE (w)-[:USES_GLYPH]->(g)
+    )
+    WITH w
+    FOREACH (chroma IN $chroma |
+        MERGE (c:Chroma {name:chroma.name})
+        SET c.hex = chroma.hex
+        MERGE (w)-[:HAS_CHROMA]->(c)
+    )
+    WITH w
+    FOREACH (entity IN $entities |
+        MERGE (e:Entity {id:entity.id})
+        SET e.name = entity.name,
+            e.type = entity.type
+        MERGE (w)-[rel:MENTIONS]->(e)
+        SET rel.role = entity.role
+    )
+    """
+    payload = {
+        "id": whisper_id,
+        "title": doc.get("title"),
+        "created_at": _format_datetime(doc.get("created_at")),
+        "visibility": doc.get("visibility", settings.default_visibility),
+        "language": doc.get("language"),
+        "maat_score": (doc.get("ethics") or {}).get("maat_score"),
+        "glyphs": glyphs,
+        "chroma": chroma_payload,
+        "entities": entity_payload,
+        "vector_ids": vector_ids,
+    }
+    with driver.session() as session:
+        session.run(cypher, **payload)
+
+
+def remove_from_graph(driver: Driver, whisper_id: str) -> None:
+    cypher = "MATCH (w:Whisper {id:$id}) DETACH DELETE w"
+    with driver.session() as session:
+        session.run(cypher, id=whisper_id)
+
+
+class ChangeStreamWorker:
+    """Stream MongoDB changes and mirror them into Neo4j."""
+
+    def __init__(self, mongo_manager: Optional[MongoManager] = None, neo4j_manager: Optional[Neo4jManager] = None) -> None:
+        self.mongo = mongo_manager or MongoManager()
+        self.neo4j = neo4j_manager or Neo4jManager()
+        self.db = self.mongo.db
+        self.driver = self.neo4j.driver
+        self.sync_state = self.db["sync_state"]
+
+    def _load_resume_token(self):
+        state = self.sync_state.find_one({"_id": "whispers"})
+        return state.get("resume_token") if state else None
+
+    def _store_resume_token(self, token) -> None:
+        self.sync_state.update_one(
+            {"_id": "whispers"},
+            {"$set": {"resume_token": token, "updated_at": datetime.utcnow()}},
+            upsert=True,
+        )
+
+    def run(self) -> None:
+        resume_token = self._load_resume_token()
+        logger.info("Starting change stream with resume token: %s", resume_token)
+        while True:
+            watch_kwargs = {"full_document": "updateLookup"}
+            if resume_token:
+                watch_kwargs["resume_after"] = resume_token
+            try:
+                with self.db["whispers"].watch(**watch_kwargs) as stream:
+                    for change in stream:
+                        resume_token = change.get("_id") or resume_token
+                        operation = change.get("operationType")
+                        if operation == "delete":
+                            key = change.get("documentKey", {}).get("_id")
+                            if key:
+                                remove_from_graph(self.driver, str(key))
+                        else:
+                            doc = change.get("fullDocument")
+                            if doc:
+                                upsert_graph(self.driver, self.db, doc)
+                        if resume_token:
+                            self._store_resume_token(resume_token)
+            except PyMongoError as exc:
+                logger.exception("Change stream error: %s", exc)
+                time.sleep(2)
+                continue
+            except KeyboardInterrupt:
+                logger.info("Worker interrupted, shutting down")
+                break
+
+    def close(self) -> None:
+        self.mongo.close()
+        self.neo4j.close()
+
+
+def main() -> None:
+    worker = ChangeStreamWorker()
+    try:
+        worker.run()
+    finally:
+        worker.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared glyph octave registry covering phases ϕ⁰–ϕ⁷ for the Hyperglyph engine
- export glyph helpers through aeon_core and surface them with a new /glyphs FastAPI endpoint
- extend the API schema with a GlyphPhase model so clients can request specific phases or the full octave

## Testing
- python -m compileall aeon_core api

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914eeab46b483258abdee41773c366d)